### PR TITLE
Migrate artifacts publishing to Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,20 @@
 [![Build Status](https://travis-ci.org/mail-ru-im/bot-java.svg?branch=master)](https://travis-ci.org/mail-ru-im/bot-java)
 [![codecov](https://codecov.io/gh/mail-ru-im/bot-java/branch/master/graph/badge.svg)](https://codecov.io/gh/mail-ru-im/bot-java)
 
-[![jcenter version](https://img.shields.io/bintray/v/mail-ru-im/maven/bot-api.svg)](https://bintray.com/mail-ru-im/maven/bot-api/_latestVersion)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/ru.mail.im/bot-api/badge.svg)](https://maven-badges.herokuapp.com/maven-central/ru.mail.im/bot-api)
 
 ## Install
 
-Group id `io.github.mail-ru-im` will no longer being maintained. We moved this artifact to the `ru.mail`  group id.
+Group ids `io.github.mail-ru-im` and `ru.mail` will no longer being maintained. We moved this artifact to the `ru.mail.im` group id.
 
 ### Maven
 ```xml
     <repositories>
         ...
         <repository>
-            <id>jcenter</id>
-            <url>https://jcenter.bintray.com</url>
+            <id>mavencentral</id>
+            <name>Maven Central Repository</name>
+            <url>http://repo1.maven.org/maven2</url>
         </repository>
         ...
     </repositories>
@@ -25,7 +26,7 @@ Group id `io.github.mail-ru-im` will no longer being maintained. We moved this a
     <dependencies>
         ...
         <dependency>
-            <groupId>ru.mail</groupId>
+            <groupId>ru.mail.im</groupId>
             <artifactId>bot-api</artifactId>
             <version>1.2.2</version>
         </dependency>
@@ -36,11 +37,11 @@ Group id `io.github.mail-ru-im` will no longer being maintained. We moved this a
 ### Gradle
 ```groovy
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {
-    implementation 'ru.mail:bot-api:1.2.2'
+    implementation 'ru.mail.im:bot-api:1.2.2'
 }
 ```
 
@@ -119,6 +120,7 @@ client.stop(); // stop when work done
 `1.2.2` 
 - Support text formats: MarkdownV2, HTML
 - Support button's style for inline keyboard
+- Moved from JCenter with `ru.mail` group id to Maven Central with `ru.mail.im` group id
 
 `1.2.1` 
 - Api response status check possibility

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,12 +1,17 @@
 plugins {
-    id "com.jfrog.bintray" version "1.8.4"
+    id "maven"
     id "maven-publish"
     id "java"
     id "jacoco"
+    id "signing"
 }
 
 targetCompatibility = versions.javaVersion
 sourceCompatibility = versions.javaVersion
+
+group = "ru.mail.im"
+archivesBaseName = "bot-api"
+version = "1.2.2"
 
 repositories {
     mavenCentral()
@@ -46,70 +51,66 @@ artifacts {
     archives javadocJar
 }
 
-def pomConfig = {
-    licenses {
-        license {
-            name "MIT License"
-            url "http://www.opensource.org/licenses/mit-license.php"
-            distribution "repo"
-        }
-    }
-    developers {
-        developer {
-            id properties['developer.id']
-            name properties['developer.name']
-            email properties['developer.email']
-        }
-    }
-
-    scm {
-        url "https://github.com/mail-ru-im/bot-java"
-    }
+signing {
+    useGpgCmd()
+    sign configurations.archives
 }
 
 File propsFile = project.rootProject.file('local.properties')
 if (propsFile.exists()) {
     Properties properties = new Properties()
     properties.load(propsFile.newDataInputStream())
-    publishing {
-        publications {
-            ApiPublication(MavenPublication) {
-                from components.java
-                artifact sourcesJar {
-                    classifier "sources"
+    uploadArchives {
+        repositories {
+            mavenDeployer {
+                beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+                repository(url: "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                    authentication(
+                            userName: properties['sonatype.ossrhUsername'],
+                            password: properties['sonatype.ossrhPassword']
+                    )
                 }
-                artifact javadocJar {
-                    classifier "javadoc"
+
+                snapshotRepository(url: "https://s01.oss.sonatype.org/content/repositories/snapshots/") {
+                    authentication(
+                            userName: properties['sonatype.ossrhUsername'],
+                            password: properties['sonatype.ossrhPassword']
+                    )
                 }
-                groupId 'ru.mail'
-                artifactId 'bot-api'
-                version '1.2.2'
-                pom.withXml {
-                    def root = asNode()
-                    root.appendNode('name', 'bot-api')
-                    root.appendNode('url', 'https://github.com/mail-ru-im/bot-java')
-                    root.children().last() + pomConfig
+
+                pom.project {
+                    name 'bot-api'
+                    packaging 'jar'
+                    // optionally artifactId can be defined here
+                    description 'Java interface for bot API'
+                    url 'https://github.com/mail-ru-im/bot-java'
+
+                    scm {
+                        connection 'scm:git:https://github.com/mail-ru-im/bot-java'
+                        developerConnection 'scm:git:https://github.com/mail-ru-im/bot-java'
+                        url 'https://github.com/mail-ru-im/bot-java'
+                    }
+
+                    licenses {
+                        license {
+                            name "MIT License"
+                            url "http://www.opensource.org/licenses/mit-license.php"
+                            distribution "repo"
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            id properties['developer.id']
+                            name properties['developer.name']
+                            email properties['developer.email']
+                        }
+                    }
                 }
             }
         }
     }
-
-    bintray {
-        user = properties['bintray.user']
-        key = properties['bintray.key']
-        publications = ['ApiPublication']
-        pkg {
-            repo = 'maven'
-            name = 'bot-api'
-            userOrg = 'mail-ru-im'
-            licenses = ['MIT']
-            vcsUrl = 'https://github.com/mail-ru-im/bot-java.git'
-            publicDownloadNumbers = false
-            version {
-                name = '1.2.2'
-            }
-        }
-
-        publish = true
-    }
+} else {
+    println("There is no local.properties file included")
 }


### PR DESCRIPTION
## Changes
- Upgraded **Gradle** from 4.4 to 4.5. To sign artifacts via gpg-agent we have to use **Gradle** 4.5 or later: [`useGpgCmd()`](https://docs.gradle.org/4.5/release-notes.html#signing-artifacts-with-gpg-agent).
- Added [`uploadArchives` configuration](https://central.sonatype.org/publish/publish-gradle/#metadata-definition-and-upload) in order to deploy components to OSSRH with Gradle. 
- Removed [deprecated](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/) `publishing` and `bintray` configurations, and Bintray's JCenter badge.
- Added Maven Central Repository badge: [![Maven Central](https://maven-badges.herokuapp.com/maven-central/ru.mail.im/bot-api/badge.svg)](https://maven-badges.herokuapp.com/maven-central/ru.mail.im/bot-api)
- Updated README.md